### PR TITLE
docs: Replace `constant` with `arith.constant`

### DIFF
--- a/include/Standalone/StandaloneOps.td
+++ b/include/Standalone/StandaloneOps.td
@@ -26,7 +26,7 @@ def Standalone_FooOp : Standalone_Op<"foo", [Pure,
         Example:
 
         ```mlir
-        %0 = constant 2 : i32
+        %0 = arith.constant 2 : i32
         // Apply the foo operation to %0
         %1 = standalone.foo %0 : i32
         ```


### PR DESCRIPTION
Fixes the documentation of `standalone.foo` operation to use `constant` instead of `arith.constant`, so people can try out the example with `standalone-opt`.